### PR TITLE
Fikser whitespace feil fra Krrstub

### DIFF
--- a/src/main/web_src/src/components/fagsystem/krrstub/visning/KrrVisning.js
+++ b/src/main/web_src/src/components/fagsystem/krrstub/visning/KrrVisning.js
@@ -10,7 +10,10 @@ export const Visning = ({ data }) => {
 		<>
 			<TitleValue title="Mobilnummer" value={data.mobil} />
 			<TitleValue title="E-post" value={data.epost} />
-			<TitleValue title="Språk" value={Formatters.showLabel('spraaktype', data.spraak)} />
+			<TitleValue
+				title="Språk"
+				value={Formatters.showLabel('spraaktype', data.spraak.replace(' ', ''))}
+			/>
 			<TitleValue
 				title="Reservert mot digitalkommunikasjon"
 				value={Formatters.oversettBoolean(data.reservert)}


### PR DESCRIPTION
Feil fra Krrstub, de legger på en whitespace etter språkkode som måtte fjernes for å vise språk.