### PR TITLE
Fiks mot bestillinger med tom inntektstub

### DIFF
--- a/src/main/web_src/src/components/bestilling/sammendrag/kriterier/BestillingKriterieMapper.js
+++ b/src/main/web_src/src/components/bestilling/sammendrag/kriterier/BestillingKriterieMapper.js
@@ -474,35 +474,36 @@ export function mapBestillingData(bestillingData, bestillingsinformasjon) {
 			itemRows: []
 		}
 
-		inntektStubKriterier.inntektsinformasjon.forEach((inntektsinfo, i) => {
-			inntektStub.itemRows.push([
-				{ numberHeader: `Inntektsinformasjon ${i + 1}` },
-				obj('Måned/år', inntektsinfo.sisteAarMaaned),
-				obj('Generer antall måneder', inntektsinfo.antallMaaneder),
-				obj('Virksomhet (orgnr/id)', inntektsinfo.virksomhet),
-				obj('Opplysningspliktig (orgnr/id)', inntektsinfo.opplysningspliktig),
-				obj(
-					'Antall registrerte inntekter',
-					inntektsinfo.inntektsliste && inntektsinfo.inntektsliste.length
-				),
-				obj(
-					'Antall registrerte fradrag',
-					inntektsinfo.fradragsliste && inntektsinfo.fradragsliste.length
-				),
-				obj(
-					'Antall registrerte forskuddstrekk',
-					inntektsinfo.forskuddstrekksliste && inntektsinfo.forskuddstrekksliste.length
-				),
-				obj(
-					'Antall registrerte arbeidsforhold',
-					inntektsinfo.arbeidsforholdsliste && inntektsinfo.arbeidsforholdsliste.length
-				),
-				obj(
-					'Antall registrerte inntektsendringer (historikk)',
-					inntektsinfo.historikk && inntektsinfo.historikk.length
-				)
-			])
-		})
+		inntektStubKriterier.inntektsinformasjon &&
+			inntektStubKriterier.inntektsinformasjon.forEach((inntektsinfo, i) => {
+				inntektStub.itemRows.push([
+					{ numberHeader: `Inntektsinformasjon ${i + 1}` },
+					obj('Måned/år', inntektsinfo.sisteAarMaaned),
+					obj('Generer antall måneder', inntektsinfo.antallMaaneder),
+					obj('Virksomhet (orgnr/id)', inntektsinfo.virksomhet),
+					obj('Opplysningspliktig (orgnr/id)', inntektsinfo.opplysningspliktig),
+					obj(
+						'Antall registrerte inntekter',
+						inntektsinfo.inntektsliste && inntektsinfo.inntektsliste.length
+					),
+					obj(
+						'Antall registrerte fradrag',
+						inntektsinfo.fradragsliste && inntektsinfo.fradragsliste.length
+					),
+					obj(
+						'Antall registrerte forskuddstrekk',
+						inntektsinfo.forskuddstrekksliste && inntektsinfo.forskuddstrekksliste.length
+					),
+					obj(
+						'Antall registrerte arbeidsforhold',
+						inntektsinfo.arbeidsforholdsliste && inntektsinfo.arbeidsforholdsliste.length
+					),
+					obj(
+						'Antall registrerte inntektsendringer (historikk)',
+						inntektsinfo.historikk && inntektsinfo.historikk.length
+					)
+				])
+			})
 
 		data.push(inntektStub)
 	}

--- a/src/main/web_src/src/components/fagsystem/aareg/form/Form.js
+++ b/src/main/web_src/src/components/fagsystem/aareg/form/Form.js
@@ -19,7 +19,12 @@ export const AaregForm = ({ formikBag }) => (
 			iconType="arbeid"
 			startOpen={() => erForste(formikBag.values, [aaregAttributt])}
 		>
-			<FormikDollyFieldArray name="aareg" header="Arbeidsforhold" newEntry={initialValues[0]}>
+			<FormikDollyFieldArray
+				name="aareg"
+				header="Arbeidsforhold"
+				newEntry={initialValues[0]}
+				canBeEmpty={false}
+			>
 				{(path, idx) => <ArbeidsforholdForm path={path} key={idx} formikBag={formikBag} />}
 			</FormikDollyFieldArray>
 		</Panel>

--- a/src/main/web_src/src/components/fagsystem/inntektstub/form/Form.tsx
+++ b/src/main/web_src/src/components/fagsystem/inntektstub/form/Form.tsx
@@ -54,6 +54,7 @@ export const InntektstubForm = ({ formikBag }: InntektstubForm) => (
 					header="Inntektsinformasjon"
 					newEntry={initialValues}
 					hjelpetekst={infotekst}
+					canBeEmpty={false}
 				>
 					{(path: string) => <InntektsinformasjonForm path={path} formikBag={formikBag} />}
 				</FormikDollyFieldArray>


### PR DESCRIPTION
Det er vel ingen grunn til at canBeEmpty ikke har vært brukt på inntektstub tidligere?