### PR TITLE
Sette doedsdato partner og barn

### DIFF
--- a/src/main/web_src/src/Routes.js
+++ b/src/main/web_src/src/Routes.js
@@ -18,7 +18,7 @@ const routes = [
 	{
 		path: '/gruppe/:gruppeId/bestilling/:personId',
 		exact: true,
-		breadcrumb: 'Legg til på personer',
+		breadcrumb: 'Legg til/endre',
 		component: BestillingsveilederConnector
 	},
 	{

--- a/src/main/web_src/src/components/bestilling/sammendrag/kriterier/BestillingKriterieMapper.js
+++ b/src/main/web_src/src/components/bestilling/sammendrag/kriterier/BestillingKriterieMapper.js
@@ -308,7 +308,7 @@ export function mapBestillingData(bestillingData, bestillingsinformasjon) {
 						obj('Bor sammen', Formatters.oversettBoolean(item.harFellesAdresse)),
 						obj(
 							'Sivilstand',
-							sisteSivilstand[0].sivilstand,
+							sisteSivilstand.length > 0 && sisteSivilstand[0].sivilstand,
 							PersoninformasjonKodeverk.Sivilstander
 						),
 						obj('Tidligere sivilstander', Formatters.arrayToString(tidligereSivilstander))

--- a/src/main/web_src/src/components/bestillingsveileder/BestillingsveilederHeader.js
+++ b/src/main/web_src/src/components/bestillingsveileder/BestillingsveilederHeader.js
@@ -26,7 +26,10 @@ export const BestillingsveilederHeader = () => {
 					<Header.TitleValue title="Basert på mal" value={opts.mal.malNavn} />
 				)}
 				{opts.is.leggTil && (
-					<Header.TitleValue title="Legg til på person" value={opts.personFoerLeggTil.tpsf.ident} />
+					<Header.TitleValue
+						title="Legg til/endre på person"
+						value={opts.personFoerLeggTil.tpsf.ident}
+					/>
 				)}
 				{opts.is.leggTil && opts.personFoerLeggTil.tpsf.importFra && (
 					<Header.TitleValue

--- a/src/main/web_src/src/components/bestillingsveileder/stegVelger/StegVelger.js
+++ b/src/main/web_src/src/components/bestillingsveileder/stegVelger/StegVelger.js
@@ -37,8 +37,6 @@ export const StegVelger = ({ initialValues, onSubmit, children }) => {
 			return
 		}
 
-		console.log('values :>> ', values)
-
 		return onSubmit(values, formikBag)
 	}
 
@@ -61,7 +59,7 @@ export const StegVelger = ({ initialValues, onSubmit, children }) => {
 
 						<CurrentStepComponent formikBag={formikBag} stateModifier={stateModifier} />
 
-						<DisplayFormikState {...formikBag} />
+						{/* <DisplayFormikState {...formikBag} /> */}
 
 						<Navigation
 							showPrevious={step > 0}

--- a/src/main/web_src/src/components/bestillingsveileder/stegVelger/StegVelger.js
+++ b/src/main/web_src/src/components/bestillingsveileder/stegVelger/StegVelger.js
@@ -37,6 +37,8 @@ export const StegVelger = ({ initialValues, onSubmit, children }) => {
 			return
 		}
 
+		console.log('values :>> ', values)
+
 		return onSubmit(values, formikBag)
 	}
 
@@ -59,7 +61,7 @@ export const StegVelger = ({ initialValues, onSubmit, children }) => {
 
 						<CurrentStepComponent formikBag={formikBag} stateModifier={stateModifier} />
 
-						{/*<DisplayFormikState {...formikBag} />*/}
+						<DisplayFormikState {...formikBag} />
 
 						<Navigation
 							showPrevious={step > 0}

--- a/src/main/web_src/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Familierelasjoner.js
+++ b/src/main/web_src/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Familierelasjoner.js
@@ -42,26 +42,7 @@ FamilierelasjonPanel.initialValues = ({ set, del, has, opts }) => ({
 		label: 'Har barn',
 		checked: has('tpsf.relasjoner.barn'),
 		add() {
-			set(
-				'tpsf.relasjoner.barn',
-				defaultBarn(opts)
-				// [
-				// 	{
-				// 		identtype: 'FNR',
-				// 		kjonn: '',
-				// 		barnType: '',
-				// 		partnerNr: null,
-				// 		borHos: '',
-				// 		erAdoptert: false,
-				// 		alder: Formatters.randomIntInRange(0, 17),
-				// 		doedsdato: null,
-				// 		spesreg: '',
-				// 		utenFastBopel: false,
-				// 		statsborgerskap: '',
-				// 		statsborgerskapRegdato: ''
-				// 	}
-				// ]
-			)
+			set('tpsf.relasjoner.barn', defaultBarn(opts))
 		},
 		remove() {
 			del('tpsf.relasjoner.barn')
@@ -86,7 +67,6 @@ const defaultPartner = opts => {
 		}
 	]
 
-	// TODO: Må funke for flere enn én partner? Eller kanskje ikke? Holder med eksisterende
 	const eksisterendePartner = [
 		{
 			ident: _get(opts, 'personFoerLeggTil.tpsf.relasjoner[0].personRelasjonMed.ident'),
@@ -96,13 +76,10 @@ const defaultPartner = opts => {
 		}
 	]
 
-	console.log('opts :>> ', opts)
-
 	const harEksisterendePartner = _get(opts, 'personFoerLeggTil.tpsf.relasjoner', []).some(
 		relasjon => relasjon.relasjonTypeNavn === 'PARTNER'
 	)
 
-	// return harEksisterendePartner ? [] : fullPartner
 	return harEksisterendePartner ? eksisterendePartner : fullPartner
 }
 
@@ -124,19 +101,18 @@ const defaultBarn = opts => {
 		}
 	]
 
-	console.log('opts :>> ', opts)
-	const harEksisterendeBarn = _get(opts, 'personFoerLeggTil.tpsf.relasjoner', []).some(
-		relasjon => relasjon.relasjonTypeNavn === 'FOEDSEL'
-	)
+	const eksisterendeRelasjoner = _get(opts, 'personFoerLeggTil.tpsf.relasjoner')
+	const eksisterendeBarn =
+		eksisterendeRelasjoner &&
+		eksisterendeRelasjoner.filter(relasjon => relasjon.relasjonTypeNavn === 'FOEDSEL')
+	const eksisterendeBarnValues =
+		eksisterendeBarn &&
+		eksisterendeBarn.map(barn => ({
+			ident: barn.personRelasjonMed.ident,
+			doedsdato: barn.personRelasjonMed.doedsdato || null
+		}))
 
-	// TODO: Må skille partnere og barn. Kanskje filtrere relasjoner på relasjonTypeNavn?
-	// TODO: Må funke på flere enn ett barn!!
-	const eksisterendeBarn = [
-		{
-			ident: _get(opts, 'personFoerLeggTil.tpsf.relasjoner[0].personRelasjonMed.ident'),
-			doedsdato:
-				_get(opts, 'personFoerLeggTil.tpsf.relasjoner[0].personRelasjonMed.doedsdato') || null
-		}
-	]
-	return harEksisterendeBarn ? eksisterendeBarn : fullBarn
+	return eksisterendeBarnValues && eksisterendeBarnValues.length > 0
+		? eksisterendeBarnValues
+		: fullBarn
 }

--- a/src/main/web_src/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Familierelasjoner.js
+++ b/src/main/web_src/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Familierelasjoner.js
@@ -42,22 +42,26 @@ FamilierelasjonPanel.initialValues = ({ set, del, has, opts }) => ({
 		label: 'Har barn',
 		checked: has('tpsf.relasjoner.barn'),
 		add() {
-			set('tpsf.relasjoner.barn', [
-				{
-					identtype: 'FNR',
-					kjonn: '',
-					barnType: '',
-					partnerNr: null,
-					borHos: '',
-					erAdoptert: false,
-					alder: Formatters.randomIntInRange(0, 17),
-					doedsdato: '',
-					spesreg: '',
-					utenFastBopel: false,
-					statsborgerskap: '',
-					statsborgerskapRegdato: ''
-				}
-			])
+			set(
+				'tpsf.relasjoner.barn',
+				defaultBarn(opts)
+				// [
+				// 	{
+				// 		identtype: 'FNR',
+				// 		kjonn: '',
+				// 		barnType: '',
+				// 		partnerNr: null,
+				// 		borHos: '',
+				// 		erAdoptert: false,
+				// 		alder: Formatters.randomIntInRange(0, 17),
+				// 		doedsdato: null,
+				// 		spesreg: '',
+				// 		utenFastBopel: false,
+				// 		statsborgerskap: '',
+				// 		statsborgerskapRegdato: ''
+				// 	}
+				// ]
+			)
 		},
 		remove() {
 			del('tpsf.relasjoner.barn')
@@ -74,7 +78,7 @@ const defaultPartner = opts => {
 			sivilstander: [{ sivilstand: '', sivilstandRegdato: '' }],
 			harFellesAdresse: true,
 			alder: Formatters.randomIntInRange(30, 60),
-			doedsdato: '',
+			doedsdato: null,
 			spesreg: '',
 			utenFastBopel: false,
 			statsborgerskap: '',
@@ -82,11 +86,12 @@ const defaultPartner = opts => {
 		}
 	]
 
-	// TODO: Må funke for flere enn én partner? Eller kanskje ikke?
+	// TODO: Må funke for flere enn én partner? Eller kanskje ikke? Holder med eksisterende
 	const eksisterendePartner = [
 		{
 			ident: _get(opts, 'personFoerLeggTil.tpsf.relasjoner[0].personRelasjonMed.ident'),
-			doedsdato: '',
+			doedsdato:
+				_get(opts, 'personFoerLeggTil.tpsf.relasjoner[0].personRelasjonMed.doedsdato') || null,
 			sivilstander: []
 		}
 	]
@@ -99,4 +104,39 @@ const defaultPartner = opts => {
 
 	// return harEksisterendePartner ? [] : fullPartner
 	return harEksisterendePartner ? eksisterendePartner : fullPartner
+}
+
+const defaultBarn = opts => {
+	const fullBarn = [
+		{
+			identtype: 'FNR',
+			kjonn: '',
+			barnType: '',
+			partnerNr: null,
+			borHos: '',
+			erAdoptert: false,
+			alder: Formatters.randomIntInRange(0, 17),
+			doedsdato: null,
+			spesreg: '',
+			utenFastBopel: false,
+			statsborgerskap: '',
+			statsborgerskapRegdato: ''
+		}
+	]
+
+	console.log('opts :>> ', opts)
+	const harEksisterendeBarn = _get(opts, 'personFoerLeggTil.tpsf.relasjoner', []).some(
+		relasjon => relasjon.relasjonTypeNavn === 'FOEDSEL'
+	)
+
+	// TODO: Må skille partnere og barn. Kanskje filtrere relasjoner på relasjonTypeNavn?
+	// TODO: Må funke på flere enn ett barn!!
+	const eksisterendeBarn = [
+		{
+			ident: _get(opts, 'personFoerLeggTil.tpsf.relasjoner[0].personRelasjonMed.ident'),
+			doedsdato:
+				_get(opts, 'personFoerLeggTil.tpsf.relasjoner[0].personRelasjonMed.doedsdato') || null
+		}
+	]
+	return harEksisterendeBarn ? eksisterendeBarn : fullBarn
 }

--- a/src/main/web_src/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Familierelasjoner.js
+++ b/src/main/web_src/src/components/bestillingsveileder/stegVelger/steg/steg1/paneler/Familierelasjoner.js
@@ -51,6 +51,7 @@ FamilierelasjonPanel.initialValues = ({ set, del, has, opts }) => ({
 					borHos: '',
 					erAdoptert: false,
 					alder: Formatters.randomIntInRange(0, 17),
+					doedsdato: '',
 					spesreg: '',
 					utenFastBopel: false,
 					statsborgerskap: '',
@@ -73,6 +74,7 @@ const defaultPartner = opts => {
 			sivilstander: [{ sivilstand: '', sivilstandRegdato: '' }],
 			harFellesAdresse: true,
 			alder: Formatters.randomIntInRange(30, 60),
+			doedsdato: '',
 			spesreg: '',
 			utenFastBopel: false,
 			statsborgerskap: '',
@@ -80,9 +82,21 @@ const defaultPartner = opts => {
 		}
 	]
 
+	// TODO: Må funke for flere enn én partner? Eller kanskje ikke?
+	const eksisterendePartner = [
+		{
+			ident: _get(opts, 'personFoerLeggTil.tpsf.relasjoner[0].personRelasjonMed.ident'),
+			doedsdato: '',
+			sivilstander: []
+		}
+	]
+
+	console.log('opts :>> ', opts)
+
 	const harEksisterendePartner = _get(opts, 'personFoerLeggTil.tpsf.relasjoner', []).some(
 		relasjon => relasjon.relasjonTypeNavn === 'PARTNER'
 	)
 
-	return harEksisterendePartner ? [] : fullPartner
+	// return harEksisterendePartner ? [] : fullPartner
+	return harEksisterendePartner ? eksisterendePartner : fullPartner
 }

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/Familierelasjoner.js
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/Familierelasjoner.js
@@ -29,7 +29,7 @@ export const Familierelasjoner = ({ formikBag }) => {
 					<Partnere formikBag={formikBag} personFoerLeggTil={opts.personFoerLeggTil} />
 				</Kategori>
 				<Kategori title="Barn" vis="tpsf.relasjoner.barn">
-					<Barn formikBag={formikBag} />
+					<Barn formikBag={formikBag} personFoerLeggTil={opts.personFoerLeggTil} />
 				</Kategori>
 			</Panel>
 		</Vis>

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/Barn.js
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/Barn.js
@@ -37,9 +37,6 @@ export const initialValuesDoedfoedt = {
 }
 
 export const Barn = ({ formikBag, personFoerLeggTil }) => {
-	console.log('formikBag :>> ', formikBag)
-	console.log('personFoerLeggTil :>> ', personFoerLeggTil)
-
 	const handleIdenttypeChange = (path, ident, isDoedfoedt) => {
 		if (ident.value === 'FDAT') {
 			formikBag.setFieldValue(`${path}`, initialValuesDoedfoedt)
@@ -73,15 +70,17 @@ export const Barn = ({ formikBag, personFoerLeggTil }) => {
 	return (
 		<FormikDollyFieldArray name="tpsf.relasjoner.barn" header="Barn" newEntry={initialValues}>
 			{(path, idx) => {
-				console.log('path :>> ', path)
 				const isDoedfoedt = _get(formikBag.values, `${path}.identtype`) === 'FDAT'
 				const eksisterendeBarn = _get(formikBag.values, `${path}.ident`)
-				const fornavn =
+				const aktuellRelasjon =
 					personFoerLeggTil &&
-					_get(personFoerLeggTil, `tpsf.relasjoner[${idx}].personRelasjonMed.fornavn`)
-				const etternavn =
-					personFoerLeggTil &&
-					_get(personFoerLeggTil, `tpsf.relasjoner[${idx}].personRelasjonMed.etternavn`)
+					eksisterendeBarn &&
+					_get(personFoerLeggTil, 'tpsf.relasjoner').filter(
+						relasjon => relasjon.personRelasjonMed.ident === eksisterendeBarn
+					)
+				const fornavn = aktuellRelasjon && aktuellRelasjon[0].personRelasjonMed.fornavn
+				const etternavn = aktuellRelasjon && aktuellRelasjon[0].personRelasjonMed.etternavn
+
 				return !eksisterendeBarn ? (
 					<React.Fragment key={idx}>
 						<FormikSelect

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/Barn.js
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/Barn.js
@@ -18,7 +18,7 @@ const initialValues = {
 	borHos: '',
 	erAdoptert: false,
 	alder: Formatters.randomIntInRange(0, 17),
-	doedsdato: '',
+	doedsdato: null,
 	spesreg: '',
 	utenFastBopel: false,
 	statsborgerskap: '',
@@ -37,6 +37,7 @@ export const initialValuesDoedfoedt = {
 }
 
 export const Barn = ({ formikBag, personFoerLeggTil }) => {
+	console.log('formikBag :>> ', formikBag)
 	console.log('personFoerLeggTil :>> ', personFoerLeggTil)
 
 	const handleIdenttypeChange = (path, ident, isDoedfoedt) => {
@@ -72,8 +73,16 @@ export const Barn = ({ formikBag, personFoerLeggTil }) => {
 	return (
 		<FormikDollyFieldArray name="tpsf.relasjoner.barn" header="Barn" newEntry={initialValues}>
 			{(path, idx) => {
+				console.log('path :>> ', path)
 				const isDoedfoedt = _get(formikBag.values, `${path}.identtype`) === 'FDAT'
-				return (
+				const eksisterendeBarn = _get(formikBag.values, `${path}.ident`)
+				const fornavn =
+					personFoerLeggTil &&
+					_get(personFoerLeggTil, `tpsf.relasjoner[${idx}].personRelasjonMed.fornavn`)
+				const etternavn =
+					personFoerLeggTil &&
+					_get(personFoerLeggTil, `tpsf.relasjoner[${idx}].personRelasjonMed.etternavn`)
+				return !eksisterendeBarn ? (
 					<React.Fragment key={idx}>
 						<FormikSelect
 							name={`${path}.identtype`}
@@ -139,6 +148,15 @@ export const Barn = ({ formikBag, personFoerLeggTil }) => {
 							/>
 						)}
 					</React.Fragment>
+				) : (
+					<>
+						<h4>
+							{fornavn} {etternavn} ({eksisterendeBarn})
+						</h4>
+						<div className="alder-component">
+							<FormikDatepicker name={`${path}.doedsdato`} label="Dødsdato" />
+						</div>
+					</>
 				)
 			}}
 		</FormikDollyFieldArray>

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/Barn.js
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/Barn.js
@@ -18,6 +18,7 @@ const initialValues = {
 	borHos: '',
 	erAdoptert: false,
 	alder: Formatters.randomIntInRange(0, 17),
+	doedsdato: '',
 	spesreg: '',
 	utenFastBopel: false,
 	statsborgerskap: '',
@@ -35,7 +36,9 @@ export const initialValuesDoedfoedt = {
 	doedsdato: ''
 }
 
-export const Barn = ({ formikBag }) => {
+export const Barn = ({ formikBag, personFoerLeggTil }) => {
+	console.log('personFoerLeggTil :>> ', personFoerLeggTil)
+
 	const handleIdenttypeChange = (path, ident, isDoedfoedt) => {
 		if (ident.value === 'FDAT') {
 			formikBag.setFieldValue(`${path}`, initialValuesDoedfoedt)

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/Partnere.js
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/Partnere.js
@@ -20,6 +20,7 @@ const initialValues = {
 	sivilstander: [{ sivilstand: '', sivilstandRegdato: '' }],
 	harFellesAdresse: false,
 	alder: Formatters.randomIntInRange(30, 60),
+	doedsdato: '',
 	spesreg: '',
 	utenFastBopel: false,
 	statsborgerskap: '',
@@ -90,6 +91,10 @@ export const Partnere = ({ formikBag, personFoerLeggTil }) => (
 						const showRemove = isLast && idx > 0 && c.ny
 						const clickRemove = () => arrayHelpers.remove(formikIdx)
 						const vurderFjernePartner = () => !c.ny && arrayHelpers.remove(formikIdx)
+						console.log('personFoerLeggTil :>> ', personFoerLeggTil)
+						console.log('c :>> ', c)
+						console.log('formikPath :>> ', formikPath)
+
 						return (
 							<DollyFaBlokk
 								key={idx}

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/Partnere.js
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/Partnere.js
@@ -91,9 +91,10 @@ export const Partnere = ({ formikBag, personFoerLeggTil }) => (
 						const showRemove = isLast && idx > 0 && c.ny
 						const clickRemove = () => arrayHelpers.remove(formikIdx)
 						const vurderFjernePartner = () => !c.ny && arrayHelpers.remove(formikIdx)
-						console.log('personFoerLeggTil :>> ', personFoerLeggTil)
-						console.log('c :>> ', c)
-						console.log('formikPath :>> ', formikPath)
+						// console.log('c :>> ', c)
+						// console.log('formikIdx :>> ', formikIdx)
+						// console.log('formikPath :>> ', formikPath)
+						// console.log('vurderFjernePartner :>> ', vurderFjernePartner)
 
 						return (
 							<DollyFaBlokk

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/Partnere.js
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/Partnere.js
@@ -90,11 +90,6 @@ export const Partnere = ({ formikBag, personFoerLeggTil }) => (
 						// Det er kun mulig å slette siste forhold
 						const showRemove = isLast && idx > 0 && c.ny
 						const clickRemove = () => arrayHelpers.remove(formikIdx)
-						const vurderFjernePartner = () => !c.ny && arrayHelpers.remove(formikIdx)
-						// console.log('c :>> ', c)
-						// console.log('formikIdx :>> ', formikIdx)
-						// console.log('formikPath :>> ', formikPath)
-						// console.log('vurderFjernePartner :>> ', vurderFjernePartner)
 
 						return (
 							<DollyFaBlokk
@@ -109,7 +104,6 @@ export const Partnere = ({ formikBag, personFoerLeggTil }) => (
 									partner={c}
 									locked={idx !== partnere.length - 1}
 									minDatoSivilstand={sisteTidligereSivilstandRegdato(partnere)}
-									vurderFjernePartner={vurderFjernePartner}
 								/>
 							</DollyFaBlokk>
 						)

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/Partnere.js
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/Partnere.js
@@ -20,7 +20,7 @@ const initialValues = {
 	sivilstander: [{ sivilstand: '', sivilstandRegdato: '' }],
 	harFellesAdresse: false,
 	alder: Formatters.randomIntInRange(30, 60),
-	doedsdato: '',
+	doedsdato: null,
 	spesreg: '',
 	utenFastBopel: false,
 	statsborgerskap: '',

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/partnere/partnerForm.tsx
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/partnere/partnerForm.tsx
@@ -18,27 +18,33 @@ interface PartnerForm {
 	partner: Partner
 	locked: boolean
 	minDatoSivilstand: string
-	vurderFjernePartner: () => void
 }
 
 export default ({ path, formikBag, partner, ...rest }: PartnerForm) => {
-	const handleDoedsdatoChange = dato => {
-		//TODO: Sivilstand blir ikke oppdatetrt første gang man velger dødsdato (kun vanlig bestilling)
+	const handleDoedsdatoChange = (dato: Date) => {
+		console.log('partner :>> ', partner)
 		const sivilstander = _get(formikBag.values, `${path}.sivilstander`)
 		const sisteSivilstand =
 			(sivilstander.length > 0 && sivilstander[sivilstander.length - 1].sivilstand) ||
 			partner.sivilstand ||
 			null
-		// console.log('sivilstander :>> ', sivilstander)
-		if (dato && sisteSivilstand === 'GIFT') {
+
+		if (dato) {
 			formikBag.setFieldValue(`${path}.doedsdato`, dato)
 
-			_get(formikBag.values, `${path}.sivilstander`).push({
-				sivilstand: 'ENKE',
-				sivilstandRegdato: dato
-			})
-		} else if (dato) {
-			formikBag.setFieldValue(`${path}.doedsdato`, dato)
+			if (sisteSivilstand === 'GIFT') {
+				_get(formikBag.values, `${path}.sivilstander`).push({
+					sivilstand: 'ENKE',
+					sivilstandRegdato: dato
+				})
+			} else if (sisteSivilstand === 'ENKE') {
+				formikBag.setFieldValue(`${path}.doedsdato`, dato)
+				sivilstander.length > 0 &&
+					formikBag.setFieldValue(`${path}.sivilstander[${sivilstander.length - 1}]`, {
+						sivilstand: 'ENKE',
+						sivilstandRegdato: dato
+					})
+			}
 		} else {
 			formikBag.setFieldValue(`${path}.doedsdato`, null)
 		}
@@ -87,7 +93,7 @@ export default ({ path, formikBag, partner, ...rest }: PartnerForm) => {
 						<FormikDatepicker
 							name={`${path}.doedsdato`}
 							label="Dødsdato"
-							onChange={dato => handleDoedsdatoChange(dato)}
+							onChange={(dato: Date) => handleDoedsdatoChange(dato)}
 						/>
 					</div>
 				</>

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/partnere/partnerForm.tsx
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/partnere/partnerForm.tsx
@@ -50,9 +50,14 @@ export default ({ path, formikBag, partner, ...rest }: PartnerForm) => (
 				<Alder basePath={path} formikBag={formikBag} title="Alder" />
 			</>
 		) : (
-			<h4>
-				{partner.fornavn} {partner.etternavn} ({partner.ident})
-			</h4>
+			<>
+				<h4>
+					{partner.fornavn} {partner.etternavn} ({partner.ident})
+				</h4>
+				<div className="alder-component">
+					<FormikDatepicker name={`${path}.doedsdato`} label="Dødsdato" />
+				</div>
+			</>
 		)}
 		<Sivilstand
 			sivilstander={partner.sivilstander}

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/partnere/partnerForm.tsx
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/partnere/partnerForm.tsx
@@ -22,7 +22,6 @@ interface PartnerForm {
 
 export default ({ path, formikBag, partner, ...rest }: PartnerForm) => {
 	const handleDoedsdatoChange = (dato: Date) => {
-		console.log('partner :>> ', partner)
 		const sivilstander = _get(formikBag.values, `${path}.sivilstander`)
 		const sisteSivilstand =
 			(sivilstander.length > 0 && sivilstander[sivilstander.length - 1].sivilstand) ||

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/partnere/partnerTypes.ts
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/partnere/partnerTypes.ts
@@ -5,6 +5,7 @@ export enum Relasjonstyper {
 export type Partner = {
 	ny?: boolean
 	sivilstander?: Array<Sivilstand>
+	sivilstand?: string
 	fornavn?: string
 	etternavn?: string
 	ident?: string

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/sivilstand/Sivilstand.js
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/sivilstand/Sivilstand.js
@@ -46,14 +46,15 @@ export const Sivilstand = ({
 						const showRemove = idx > 0 && isLast && !locked && ny
 						const clickRemove = () => {
 							arrayHelpers.remove(formikIdx)
-							if (formikIdx === 0) vurderFjernePartner()
+							// if (formikIdx === 0) vurderFjernePartner()
 						}
 						return (
 							<DollyFaBlokk
 								key={idx}
 								idx={idx}
 								header="Forhold"
-								handleRemove={showRemove && clickRemove}
+								handleRemove={clickRemove}
+								showDeleteButton={showRemove}
 							>
 								<SivilstandForm
 									formikPath={formikPath}

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/sivilstand/Sivilstand.js
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/familierelasjoner/partials/partnere/sivilstand/Sivilstand.js
@@ -12,14 +12,7 @@ import SivilstandForm from './sivilstandForm'
 const isSivilstandNy = sivilstand => sivilstand.ny || !sivilstand.hasOwnProperty('ny')
 const initialValues = { sivilstand: '', sivilstandRegdato: '' }
 
-export const Sivilstand = ({
-	basePath,
-	formikBag,
-	locked,
-	sivilstander,
-	minDatoSivilstand,
-	vurderFjernePartner
-}) => (
+export const Sivilstand = ({ basePath, formikBag, locked, sivilstander, minDatoSivilstand }) => (
 	<FieldArray name={basePath}>
 		{arrayHelpers => {
 			const antallTidligereSivilstander = sivilstander.filter(
@@ -46,7 +39,6 @@ export const Sivilstand = ({
 						const showRemove = idx > 0 && isLast && !locked && ny
 						const clickRemove = () => {
 							arrayHelpers.remove(formikIdx)
-							// if (formikIdx === 0) vurderFjernePartner()
 						}
 						return (
 							<DollyFaBlokk

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/personinformasjon/partials/alder/Alder.js
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/personinformasjon/partials/alder/Alder.js
@@ -24,7 +24,7 @@ const initialValue = (basePath, formikBag) => {
 		: null
 }
 
-export const Alder = ({ basePath, formikBag, title }) => {
+export const Alder = ({ basePath, formikBag, title, handleDoed }) => {
 	const [alderType, setAlderType] = useState(initialValue(basePath, formikBag))
 	const paths = {
 		alder: `${basePath}.alder`,
@@ -89,7 +89,11 @@ export const Alder = ({ basePath, formikBag, title }) => {
 					<FormikDatepicker name={paths.foedtEtter} label="Født etter" />
 					<FormikDatepicker name={paths.foedtFoer} label="Født før" />
 					<Vis attributt={paths.doedsdato}>
-						<FormikDatepicker name={paths.doedsdato} label="Dødsdato" />
+						{handleDoed ? (
+							<FormikDatepicker name={paths.doedsdato} label="Dødsdato" onChange={handleDoed} />
+						) : (
+							<FormikDatepicker name={paths.doedsdato} label="Dødsdato" />
+						)}
 					</Vis>
 				</div>
 			</div>

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/validation.js
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/validation.js
@@ -293,10 +293,11 @@ const barn = Yup.array()
 		Yup.object({
 			identtype: Yup.string(),
 			kjonn: Yup.string().nullable(),
-			barnType: requiredString,
+			barnType: ifPresent('$tpsf.relasjoner.barn[0].barnType', requiredString),
 			partnerNr: Yup.number().nullable(),
+			// TODO: Må muligens tilpasse denne nå som vi har med dødsdato
 			borHos: Yup.mixed().when('doedsdato', {
-				is: val => val === undefined,
+				is: val => val === undefined || val === null,
 				then: requiredString
 			}),
 			erAdoptert: Yup.boolean(),
@@ -320,11 +321,14 @@ const barn = Yup.array()
 			boadresse: Yup.object({
 				kommunenr: Yup.string().nullable()
 			}),
-			foedselsdato: Yup.mixed().when('borHos', {
-				is: val => val === undefined,
-				then: requiredDate
-			}),
-			doedsdato: Yup.date()
+			foedselsdato: ifPresent(
+				'$tpsf.relasjoner.barn[0].foedselsdato',
+				Yup.mixed().when('borHos', {
+					is: val => val === undefined,
+					then: requiredDate
+				})
+			),
+			doedsdato: Yup.date().nullable()
 		})
 	)
 	.nullable()

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/validation.js
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/validation.js
@@ -141,6 +141,7 @@ export const sivilstander = Yup.array().of(
 	Yup.object({
 		sivilstand: Yup.string().required(messages.required),
 		sivilstandRegdato: Yup.date()
+			.transform((i, j) => (j === null || j === '' ? undefined : i))
 			.test(
 				'is-after-last',
 				'Dato må være etter tidligere forhold (eldste forhold settes først)',
@@ -295,11 +296,13 @@ const barn = Yup.array()
 			kjonn: Yup.string().nullable(),
 			barnType: ifPresent('$tpsf.relasjoner.barn[0].barnType', requiredString),
 			partnerNr: Yup.number().nullable(),
-			// TODO: Må muligens tilpasse denne nå som vi har med dødsdato
-			borHos: Yup.mixed().when('doedsdato', {
-				is: val => val === undefined || val === null,
-				then: requiredString
-			}),
+			borHos: ifPresent(
+				'$tpsf.relasjoner.barn[0].borHos',
+				Yup.mixed().when('doedsdato', {
+					is: val => val === undefined || val === null,
+					then: requiredString
+				})
+			),
 			erAdoptert: Yup.boolean(),
 			alder: Yup.number()
 				.transform(num => (isNaN(num) ? undefined : num))

--- a/src/main/web_src/src/components/fagsystem/tpsf/form/validation.js
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/validation.js
@@ -140,7 +140,7 @@ const midlertidigAdresse = Yup.object({
 export const sivilstander = Yup.array().of(
 	Yup.object({
 		sivilstand: Yup.string().required(messages.required),
-		sivilstandRegdato: Yup.string()
+		sivilstandRegdato: Yup.date()
 			.test(
 				'is-after-last',
 				'Dato må være etter tidligere forhold (eldste forhold settes først)',

--- a/src/main/web_src/src/pages/gruppe/PersonVisning/PersonVisning.js
+++ b/src/main/web_src/src/pages/gruppe/PersonVisning/PersonVisning.js
@@ -37,7 +37,7 @@ export const PersonVisning = ({
 	iLaastGruppe
 }) => {
 	useMount(fetchDataFraFagsystemer)
-	// console.log('data :>> ', data)
+
 	return (
 		<div className="person-visning">
 			<TpsfVisning data={TpsfVisning.filterValues(data.tpsf, bestillingsListe)} />

--- a/src/main/web_src/src/pages/gruppe/PersonVisning/PersonVisning.js
+++ b/src/main/web_src/src/pages/gruppe/PersonVisning/PersonVisning.js
@@ -37,7 +37,7 @@ export const PersonVisning = ({
 	iLaastGruppe
 }) => {
 	useMount(fetchDataFraFagsystemer)
-
+	// console.log('data :>> ', data)
 	return (
 		<div className="person-visning">
 			<TpsfVisning data={TpsfVisning.filterValues(data.tpsf, bestillingsListe)} />

--- a/src/main/web_src/src/pages/gruppe/PersonVisning/PersonVisning.js
+++ b/src/main/web_src/src/pages/gruppe/PersonVisning/PersonVisning.js
@@ -72,7 +72,7 @@ export const PersonVisning = ({
 			<div className="person-visning_actions">
 				{!iLaastGruppe && (
 					<Button onClick={() => leggTilPaaPerson(data)} kind="add-circle">
-						LEGG TIL
+						LEGG TIL/ENDRE
 					</Button>
 				)}
 				{!iLaastGruppe && (

--- a/src/main/web_src/src/pages/tpsEndring/TpsEndring.js
+++ b/src/main/web_src/src/pages/tpsEndring/TpsEndring.js
@@ -20,8 +20,8 @@ export default class TPSEndring extends PureComponent {
 							forelder. Her finnes to alternativer:
 							<ul>
 								<li>
-									Velg "Legg til", og huk av for "Barn" i første steg. I neste steg kan et utvalg av
-									egenskaper velges for barnet.
+									Velg "Legg til/endre", og huk av for "Barn" i første steg. I neste steg kan et
+									utvalg av egenskaper velges for barnet.
 								</li>
 								<li>
 									Hvis barnet (og eventuelt den andre forelderen) allerede er opprettet i
@@ -31,8 +31,10 @@ export default class TPSEndring extends PureComponent {
 						</li>
 						<li>
 							<b>Sende dødsmelding:</b> Gå til testdatagruppe og finn personen det skal sendes
-							dødsmelding på. Velg "Legg til", og huk av for "Dødsdato" i første steg. I neste steg
-							kan dødsdatoen settes, før dødsmeldingen sendes som en vanlig bestilling.
+							dødsmelding på. Velg "Legg til/endre", og huk av for "Dødsdato" i første steg. I neste
+							steg kan dødsdatoen settes, før dødsmeldingen sendes som en vanlig bestilling. For å
+							sende dødsmelding på personens partner/barn må partner eller barn hukes av i første
+							steg. Da vil det være mulig å sette dødsdato på eksisterende relasjoener i steg to.
 						</li>
 						<li>
 							For personer som ikke eksisterer i Dolly må disse først hentes inn ved å opprette


### PR DESCRIPTION
Liten irriterende sak jeg ikke har klart å løse, men som jeg gjerne tar imot innspill på dersom noen skulle se noe jeg ikke gjør 😉 :
Når man legger til dødsdato på eksisterende gift partner blir sivilstand satt automatisk til "ENKE". Ville gjerne ha samme funksjonaliteten på vanlig bestilling, dersom man har satt sivilstand til "GIFT" før man velger dødsdato. Men her får jeg det ikke til å fungere. Forsøker å hente opp siste sivilstand fra formikBag i handleDoedsdatoChange() i partnerForm.tsx, men det virker ikke som den blir oppdatert i tide - den er nemlig fortsatt blank når jeg gjør sjekken 🤔 