### PR TITLE
Legg til tracking av bestillinger

### DIFF
--- a/src/main/java/no/nav/dolly/web/domain/Level.java
+++ b/src/main/java/no/nav/dolly/web/domain/Level.java
@@ -3,5 +3,6 @@ package no.nav.dolly.web.domain;
 public enum Level{
     WARNING,
     ERROR,
-    INFO
+    INFO,
+    TRACE
 }

--- a/src/main/java/no/nav/dolly/web/service/LogService.java
+++ b/src/main/java/no/nav/dolly/web/service/LogService.java
@@ -21,6 +21,9 @@ public class LogService {
         MDC.clear();
         MDC.setContextMap(event.toPropertyMap());
         switch (event.getLevel()) {
+            case TRACE:
+                log.trace(event.getMessage());
+                break;
             case INFO:
                 log.info(event.getMessage());
                 break;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -29,4 +29,8 @@
     <logger name="no.nav.dolly.web.logging.LogRequestInterceptor">
         <level value="TRACE"/>
     </logger>
+    <logger name="no.nav.dolly.web.service.LogService">
+        <level value="TRACE"/>
+    </logger>
+
 </configuration>

--- a/src/main/web_src/src/components/bestillingsveileder/utils.js
+++ b/src/main/web_src/src/components/bestillingsveileder/utils.js
@@ -1,6 +1,6 @@
 import _has from 'lodash/has'
 
-const rootPaths = [
+export const rootPaths = [
 	'tpsf',
 	'pdlforvalter',
 	'aareg',

--- a/src/main/web_src/src/ducks/bestilling/index.js
+++ b/src/main/web_src/src/ducks/bestilling/index.js
@@ -1,9 +1,12 @@
 import { createActions } from 'redux-actions'
-import { push, LOCATION_CHANGE } from 'connected-react-router'
+import { LOCATION_CHANGE, push } from 'connected-react-router'
 import { DollyApi } from '~/service/Api'
 import _set from 'lodash/fp/set'
 import _get from 'lodash/get'
 import { handleActions } from '~/ducks/utils/immerHandleActions'
+import { rootPaths } from '@/components/bestillingsveileder/utils'
+import Logger from '@/logger'
+import { v4 as uuid } from 'uuid'
 
 export const actions = createActions(
 	{
@@ -31,6 +34,20 @@ export default handleActions(
 	initialState
 )
 
+const trackBestilling = values => {
+	console.log(Object.keys(values))
+
+	const _uuid = uuid()
+	Object.keys(values)
+		.filter(key => rootPaths.find(value => value === key))
+		.forEach(key => {
+			Logger.trace({
+				event: 'Bestilling av omraade: ' + key,
+				uuid: _uuid
+			})
+		})
+}
+
 /**
  * Sender de ulike bestillingstypene fra Bestillingsveileder
  */
@@ -48,6 +65,8 @@ export const sendBestilling = (values, opts, gruppeId) => async (dispatch, getSt
 	} else {
 		// Sett identType (denne blir ikke satt tidligere grunnet at den sitter inne i tpsf-noden)
 		values = _set('tpsf.identtype', opts.identtype, values)
+
+		trackBestilling(values)
 		bestillingAction = actions.postBestilling(gruppeId, values)
 	}
 

--- a/src/main/web_src/src/ducks/bestilling/index.js
+++ b/src/main/web_src/src/ducks/bestilling/index.js
@@ -35,8 +35,6 @@ export default handleActions(
 )
 
 const trackBestilling = values => {
-	console.log(Object.keys(values))
-
 	const _uuid = uuid()
 	Object.keys(values)
 		.filter(key => rootPaths.find(value => value === key))

--- a/src/main/web_src/src/logger/index.ts
+++ b/src/main/web_src/src/logger/index.ts
@@ -30,6 +30,7 @@ interface Log {
 }
 
 export default {
+	trace: ({ event, message, uuid }: Log) => log(Level.TRACE, event, message, uuid),
 	log: ({ event, message, uuid, rating, isAnonym }: Log) =>
 		log(Level.INFO, event, message, uuid, rating, isAnonym),
 	warn: ({ event, message, uuid, rating }: Log) => log(Level.WARNING, event, message, uuid, rating),

--- a/src/main/web_src/src/logger/types.ts
+++ b/src/main/web_src/src/logger/types.ts
@@ -1,4 +1,5 @@
 export enum Level {
+	TRACE = 'TRACE',
 	INFO = 'INFO',
 	WARNING = 'WARNING',
 	ERROR = 'ERROR'


### PR DESCRIPTION
Hadde lyst til å legge inn en rask bestilligs tracking slik av vi vet hva folk bruker. 

Vi kan legge til mer info senere men da tror jeg vi burde legge til et nytt endepunkt i stede for å bruke logg