### PR TITLE
Graceful error håndtering dersom Profil API feiler

### DIFF
--- a/src/main/web_src/src/ducks/bruker/index.js
+++ b/src/main/web_src/src/ducks/bruker/index.js
@@ -1,5 +1,5 @@
 import { DollyApi, ProfilApi } from '~/service/Api'
-import { createActions, combineActions } from 'redux-actions'
+import { combineActions, createActions } from 'redux-actions'
 import { handleActions } from '~/ducks/utils/immerHandleActions'
 import { onSuccess } from '~/ducks/utils/requestActions'
 
@@ -38,10 +38,10 @@ export default handleActions(
 			state.brukerData = action.payload.data
 		},
 		[onSuccess(getCurrentBrukerProfil)](state, action) {
-			state.brukerProfil = action.payload.data
+			state.brukerProfil = action.payload ? action.payload.data : null
 		},
 		[onSuccess(getCurrentBrukerBilde)](state, action) {
-			state.brukerBilde = action.payload.data
+			state.brukerBilde = action.payload ? action.payload.data : null
 		}
 	},
 	initialState

--- a/src/main/web_src/src/service/services/profil/ProfilService.tsx
+++ b/src/main/web_src/src/service/services/profil/ProfilService.tsx
@@ -1,11 +1,23 @@
 import Request from '~/service/services/Request'
+import Logger from '~/logger'
 
 const getProfilUrl = '/api/testnorge-profil-api'
+
+function logError(error: any) {
+	Logger.error({
+		event: `Profil API feilet`,
+		message: error.message
+	})
+}
 
 export default {
 	getProfil() {
 		const endpoint = getProfilUrl + '/profil'
 		return Request.get(endpoint)
+			.then(response => {
+				if (response != null) return response
+			})
+			.catch(error => logError(error))
 	},
 
 	getProfilBilde() {
@@ -14,6 +26,6 @@ export default {
 			.then(response => {
 				if (response != null) return response
 			})
-			.catch(error => null)
+			.catch(error => logError(error))
 	}
 }


### PR DESCRIPTION
Prøver å catche error og håndterer null slik at det er mulig å gjennomføre bestilling dersom Profil API feiler under hent av profil/bilde