### PR TITLE
Fjernet kryptisk Json Error for bruker dersom service er nede.

### DIFF
--- a/src/main/web_src/src/components/varslinger/VarslingerModal.tsx
+++ b/src/main/web_src/src/components/varslinger/VarslingerModal.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react'
-import { isBefore, isAfter } from 'date-fns'
+import { isAfter, isBefore } from 'date-fns'
 import DollyModal from '~/components/ui/modal/DollyModal'
 import Stegindikator from 'nav-frontend-stegindikator'
 import NavButton from '~/components/ui/button/NavButton/NavButton'
 import { VarslingerTekster } from './VarslingerTekster'
 import './varslingerModal.less'
+import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
 
 interface Varslinger {
 	varslinger: Array<Varsling>
@@ -27,6 +28,8 @@ export const VarslingerModal = ({
 }: Varslinger) => {
 	const [steg, setSteg] = useState(0)
 	const [modalOpen, setModalOpen] = useState(true)
+
+	if (!varslinger) return null
 
 	const usetteVarslinger =
 		isLoadingVarslinger === false &&
@@ -54,39 +57,47 @@ export const VarslingerModal = ({
 	}
 
 	return (
-		<DollyModal isOpen={modalOpen} noCloseButton={true} width="70%" overflow="auto">
-			<div className="varslinger-modal">
-				{/* 
+		<ErrorBoundary>
+			<DollyModal isOpen={modalOpen} noCloseButton={true} width="70%" overflow="auto">
+				<div className="varslinger-modal">
+					{/* 
                 //@ts-ignore */}
-				{antallVarslinger > 1 && <Stegindikator aktivtSteg={steg} steg={varslingerSteg} kompakt />}
-
-				<VarslingerTekster varslingId={gyldigeVarslinger[steg].varslingId} />
-
-				<div className="varslinger-buttons">
-					{steg > 0 && (
-						<NavButton type="standard" onClick={() => setSteg(steg - 1)} style={{ float: 'left' }}>
-							Forrige side
-						</NavButton>
+					{antallVarslinger > 1 && (
+						<Stegindikator aktivtSteg={steg} steg={varslingerSteg} kompakt />
 					)}
-					{steg < antallVarslinger - 1 ? (
-						<NavButton
-							type="hoved"
-							onClick={() => submitSettVarsling(false)}
-							style={{ float: 'right' }}
-						>
-							Neste side
-						</NavButton>
-					) : (
-						<NavButton
-							type="hoved"
-							onClick={() => submitSettVarsling(true)}
-							style={{ float: 'right' }}
-						>
-							Lukk
-						</NavButton>
-					)}
+
+					<VarslingerTekster varslingId={gyldigeVarslinger[steg].varslingId} />
+
+					<div className="varslinger-buttons">
+						{steg > 0 && (
+							<NavButton
+								type="standard"
+								onClick={() => setSteg(steg - 1)}
+								style={{ float: 'left' }}
+							>
+								Forrige side
+							</NavButton>
+						)}
+						{steg < antallVarslinger - 1 ? (
+							<NavButton
+								type="hoved"
+								onClick={() => submitSettVarsling(false)}
+								style={{ float: 'right' }}
+							>
+								Neste side
+							</NavButton>
+						) : (
+							<NavButton
+								type="hoved"
+								onClick={() => submitSettVarsling(true)}
+								style={{ float: 'right' }}
+							>
+								Lukk
+							</NavButton>
+						)}
+					</div>
 				</div>
-			</div>
-		</DollyModal>
+			</DollyModal>
+		</ErrorBoundary>
 	)
 }

--- a/src/main/web_src/src/ducks/varslinger/index.js
+++ b/src/main/web_src/src/ducks/varslinger/index.js
@@ -20,10 +20,10 @@ const initialState = {
 export default handleActions(
 	{
 		[onSuccess(getVarslinger)](state, action) {
-			state.varslingerData = action.payload.data
+			state.varslingerData = action.payload ? action.payload.data : null
 		},
 		[onSuccess(getVarslingerBruker)](state, action) {
-			state.varslingerBrukerData = action.payload.data
+			state.varslingerBrukerData = action.payload ? action.payload.data : null
 		}
 	},
 	initialState

--- a/src/main/web_src/src/service/services/Request.ts
+++ b/src/main/web_src/src/service/services/Request.ts
@@ -1,15 +1,19 @@
 import api from '@/api'
+import Logger from '~/logger'
 
 export default class Request {
 	static get(url: string, headers: Record<string, string> = {}) {
-		return api.fetchJson(url, { headers, method: 'GET' }).then(response => ({ data: response }))
+		return api
+			.fetchJson(url, { headers, method: 'GET' })
+			.then(response => ({ data: response }))
+			.catch(error => Request.logError(error, url))
 	}
 
 	static getBilde(url: string) {
 		return api
 			.fetch(url, { method: 'GET' })
 			.then(response => ({ data: response }))
-			.catch(error => null)
+			.catch(error => Request.logError(error, url))
 	}
 
 	static post(url: string, data?: object) {
@@ -26,5 +30,13 @@ export default class Request {
 
 	static delete(url: string) {
 		return api.fetch(url, { method: 'DELETE' })
+	}
+
+	private static logError(error: any, url: string) {
+		const event = `Henting av data fra ${url} feilet`
+		Logger.error({
+			event: event,
+			message: error.message
+		})
 	}
 }

--- a/src/main/web_src/src/service/services/profil/ProfilService.tsx
+++ b/src/main/web_src/src/service/services/profil/ProfilService.tsx
@@ -1,31 +1,19 @@
 import Request from '~/service/services/Request'
-import Logger from '~/logger'
 
 const getProfilUrl = '/api/testnorge-profil-api'
-
-function logError(error: any) {
-	Logger.error({
-		event: `Profil API feilet`,
-		message: error.message
-	})
-}
 
 export default {
 	getProfil() {
 		const endpoint = getProfilUrl + '/profil'
-		return Request.get(endpoint)
-			.then(response => {
-				if (response != null) return response
-			})
-			.catch(error => logError(error))
+		return Request.get(endpoint).then(response => {
+			if (response != null) return response
+		})
 	},
 
 	getProfilBilde() {
 		const endpoint = getProfilUrl + '/profil/bilde'
-		return Request.getBilde(endpoint)
-			.then(response => {
-				if (response != null) return response
-			})
-			.catch(error => logError(error))
+		return Request.getBilde(endpoint).then(response => {
+			if (response != null) return response
+		})
 	}
 }


### PR DESCRIPTION
[Trello issue](https://trello.com/c/RVGNRbwt/229-dolly-frontend-forbedre-tilbakemelding-ved-feilsituasjon-cannot-read-property-json-of-null)

Gjelder alle get kall istedenfor bare profil-api, ettersom Dolly også mister mye funksjonalitet dersom varslinger er nede. Er det forresten nødvendig for bruker å vite at en service er nede, dersom det ikke påvirker normal funksjonalitet? Eneste jeg tenkte på er at en ny bruker potensielt ikke får varsling om bruksvilkår før dolly kan tas i bruk med disse endringene dersom Varslinger API er nede 😅  