### PR TITLE
Vise riktig antall bestillinger i toggle

### DIFF
--- a/src/main/web_src/src/pages/gruppe/Gruppe.js
+++ b/src/main/web_src/src/pages/gruppe/Gruppe.js
@@ -27,10 +27,11 @@ export default function Gruppe({
 	isDeletingGruppe,
 	isLockingGruppe,
 	match,
-	history
+	history,
+	bestillingStatuser
 }) {
 	const [visning, setVisning] = useState(VISNING_PERSONER)
-	const [startBestillingAktiv, visStartBestilling, skjulStarBestilling] = useBoolean(false)
+	const [startBestillingAktiv, visStartBestilling, skjulStartBestilling] = useBoolean(false)
 	useMount(() => {
 		getGruppe()
 		getBestillinger()
@@ -52,9 +53,6 @@ export default function Gruppe({
 	const searchfieldPlaceholderSelector = () => {
 		if (visning === VISNING_BESTILLING) return 'Søk i bestillinger'
 		return 'Søk etter personer'
-	}
-	const countUnique = iterable => {
-		return new Set(iterable).size
 	}
 
 	const erLaast = gruppe.erLaast
@@ -92,7 +90,7 @@ export default function Gruppe({
 							size={13}
 							kind={visning === VISNING_BESTILLING ? 'bestillingLight' : 'bestilling'}
 						/>
-						{`Bestillinger (${countUnique(Object.values(identer))})`}
+						{`Bestillinger (${Object.keys(bestillingStatuser).length})`}
 					</ToggleKnapp>
 				</ToggleGruppe>
 
@@ -102,7 +100,7 @@ export default function Gruppe({
 			{startBestillingAktiv && (
 				<BestillingsveilederModal
 					onSubmit={startBestilling}
-					onAvbryt={skjulStarBestilling}
+					onAvbryt={skjulStartBestilling}
 					brukernavn={brukernavn}
 				/>
 			)}

--- a/src/main/web_src/src/pages/gruppe/GruppeConnector.js
+++ b/src/main/web_src/src/pages/gruppe/GruppeConnector.js
@@ -14,7 +14,8 @@ const mapStateToProps = (state, ownProps) => ({
 	isLockingGruppe: loadingSelectorLaasGruppe(state),
 	gruppe: selectGruppeById(state, ownProps.match.params.gruppeId),
 	identer: state.gruppe.ident,
-	brukernavn: state.bruker.brukerData.brukernavn
+	brukernavn: state.bruker.brukerData.brukernavn,
+	bestillingStatuser: state.bestillingStatuser.byId
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => {


### PR DESCRIPTION
Kan f.eks. sammenligne gruppe 64 i dolly-frontend-dev der det nå viser at det skal være 50 bestillinger, men er egentlig bare 31.