### PR TITLE
Bugfix - fjerner tilleggsinformasjon når tilleggsinformasjonstype er null

### DIFF
--- a/src/main/web_src/src/components/inntektStub/validerInntekt/index.js
+++ b/src/main/web_src/src/components/inntektStub/validerInntekt/index.js
@@ -49,13 +49,14 @@ const InntektStub = ({ formikBag, inntektPath }) => {
 			inntektstype: values.inntektstype
 		}
 
-		// TODO: Denne må gjøres ferdig - må nullstille tilleggsinformasjon når tilleggsinformasjonstype endres
 		if (values.inntektstype !== currentInntektstype) {
 			formikBag.setFieldValue(inntektPath, nullstiltInntekt)
 		} else {
 			for (const [key, value] of Object.entries(values)) {
 				if (key === 'tilleggsinformasjonstype') {
-					if (value !== currentTilleggsinformasjonstype) {
+					if (value === null) {
+						formikBag.setFieldValue(`${inntektPath}.tilleggsinformasjon`, undefined)
+					} else if (value !== currentTilleggsinformasjonstype) {
 						formikBag.setFieldValue(`${inntektPath}.tilleggsinformasjon`, {})
 					}
 					setCurrentTilleggsinformasjonstype(value)


### PR DESCRIPTION
Ref. bug i inntektstub-form fra kanalen.
Ble en bitteliten fix, og jeg er litt skeptisk, fordi dette tydeligvis ikke er noe jeg har prioritert å fikse tidligere. Men det var ikke mye som skulle til, for det ser ut til å funke bedre nå. Men lager en PR i tilfelle dere ser noe jeg ikke ser 😉 