### PR TITLE
Validering - ikke lov å skrive inn ugyldig dato på inntektstub

### DIFF
--- a/src/main/web_src/src/components/fagsystem/inntektstub/form/validation.js
+++ b/src/main/web_src/src/components/fagsystem/inntektstub/form/validation.js
@@ -148,7 +148,10 @@ export const validation = {
 	inntektstub: Yup.object({
 		inntektsinformasjon: Yup.array().of(
 			Yup.object({
-				sisteAarMaaned: requiredString,
+				sisteAarMaaned: requiredString.matches(/^\d{4}\-(0[1-9]|1[012])$/, {
+					message: 'Dato må være på formatet yyyy-MM',
+					excludeEmptyString: true
+				}),
 				antallMaaneder: Yup.number()
 					.integer('Kan ikke være et desimaltall')
 					.transform((i, j) => (j === '' ? null : i))


### PR DESCRIPTION
Det var mulig å skrive inn år med 6 digits på år/måned i Inntektstub - har laget en validering slik at man ikke kommer videre med ugyldig dato.