### PR TITLE
Endret til å vise liste istedenfor historikk, mindre refaktorering

### DIFF
--- a/src/main/web_src/src/components/fagsystem/tpsf/form/personinformasjon/partials/fullmakt/Fullmakt.tsx
+++ b/src/main/web_src/src/components/fagsystem/tpsf/form/personinformasjon/partials/fullmakt/Fullmakt.tsx
@@ -23,15 +23,17 @@ export const Fullmakt = () => {
 		<Vis attributt={Object.values(paths)} formik>
 			<div className="flexbox--flex-wrap">
 				<FormikTextInput name={paths.kilde} label="Kilde" size="xlarge" />
-				<FormikSelect
-					name={paths.omraader}
-					label="Områder"
-					options={fullmaktOptions}
-					size="xlarge"
-					isMulti={true}
-					isClearable={false}
-					fastfield={false}
-				/>
+				<div className="flexbox--full-width">
+					<FormikSelect
+						name={paths.omraader}
+						label="Områder"
+						options={fullmaktOptions}
+						size="grow"
+						isMulti={true}
+						isClearable={false}
+						fastfield={false}
+					/>
+				</div>
 				<FormikDatepicker name={paths.gyldigFom} label="Gyldig fra og med" />
 				<FormikDatepicker name={paths.gyldigTom} label="Gyldig til og med" />
 				<FormikSelect

--- a/src/main/web_src/src/components/fagsystem/tpsf/visning/partials/Fullmakt.tsx
+++ b/src/main/web_src/src/components/fagsystem/tpsf/visning/partials/Fullmakt.tsx
@@ -5,7 +5,7 @@ import Formatters from '~/utils/DataFormatter'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
 import { DollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
 import { FullmaktKodeverk } from '~/config/kodeverk'
-import { Kategori } from '~/components/ui/form/kategori/Kategori'
+import styled from 'styled-components'
 
 type Data = {
 	data: FullmaktData
@@ -33,13 +33,29 @@ type Fullmektig = {
 	kjonn: string
 }
 
+const Tema = styled.div`
+	h4 {
+		width: 100%;
+		margin-bottom: 10px;
+		margin-top: 0px;
+	}
+	TitleValue {
+		margin-bottom: 5px;
+	}
+`
+
 export const Visning = ({ data }: Data) => {
 	const { etternavn, fornavn, ident, identtype, kjonn, mellomnavn } = data.fullmektig
 
 	return (
 		<>
-			<div className="person-visning_content">
-				<ErrorBoundary>
+			<ErrorBoundary>
+				<div className="person-visning_content">
+					<TitleValue title="Kilde" value={data.kilde} />
+					<TitleValue title="Gyldig fra og med" value={Formatters.formatDate(data.gyldigFom)} />
+					<TitleValue title="Gyldig til og med" value={Formatters.formatDate(data.gyldigTom)} />
+				</div>
+				<Tema>
 					<h4>Tema</h4>
 					{data.omraader.map((omraade: string) =>
 						omraade.includes('*') ? (
@@ -53,19 +69,16 @@ export const Visning = ({ data }: Data) => {
 							/>
 						)
 					)}
-					<TitleValue title="Kilde" value={data.kilde} />
-					<TitleValue title="Gyldig fra og med" value={Formatters.formatDate(data.gyldigFom)} />
-					<TitleValue title="Gyldig til og med" value={Formatters.formatDate(data.gyldigTom)} />
-				</ErrorBoundary>
-			</div>
-			<h4 style={{ marginTop: '0px' }}>Fullmektig</h4>
-			<div className="person-visning_content">
-				<TitleValue title={identtype} value={ident} />
-				<TitleValue title="Fornavn" value={fornavn} />
-				<TitleValue title="Mellomnavn" value={mellomnavn} />
-				<TitleValue title="Etternavn" value={etternavn} />
-				<TitleValue title="Kjønn" value={Formatters.kjonnToString(kjonn)} />
-			</div>
+				</Tema>
+				<div className="person-visning_content">
+					<h4 style={{ width: '100%' }}>Fullmektig</h4>
+					<TitleValue title={identtype} value={ident} />
+					<TitleValue title="Fornavn" value={fornavn} />
+					<TitleValue title="Mellomnavn" value={mellomnavn} />
+					<TitleValue title="Etternavn" value={etternavn} />
+					<TitleValue title="Kjønn" value={Formatters.kjonnToString(kjonn)} />
+				</div>
+			</ErrorBoundary>
 		</>
 	)
 }

--- a/src/main/web_src/src/components/fagsystem/tpsf/visning/partials/Fullmakt.tsx
+++ b/src/main/web_src/src/components/fagsystem/tpsf/visning/partials/Fullmakt.tsx
@@ -5,6 +5,7 @@ import Formatters from '~/utils/DataFormatter'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
 import { DollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
 import { FullmaktKodeverk } from '~/config/kodeverk'
+import { Kategori } from '~/components/ui/form/kategori/Kategori'
 
 type Data = {
 	data: FullmaktData
@@ -39,15 +40,19 @@ export const Visning = ({ data }: Data) => {
 		<>
 			<div className="person-visning_content">
 				<ErrorBoundary>
-					<DollyFieldArray header={'Områder'} data={data.omraader} nested>
-						{(omraade: string) =>
-							omraade.includes('*') ? (
-								<TitleValue title="Tema" value={'Alle (*)'} />
-							) : (
-								<TitleValue title="Tema" kodeverk={FullmaktKodeverk.Tema} value={omraade} />
-							)
-						}
-					</DollyFieldArray>
+					<h4>Tema</h4>
+					{data.omraader.map((omraade: string) =>
+						omraade.includes('*') ? (
+							<TitleValue key={omraade} value={'Alle (*)'} size={'full-width'} />
+						) : (
+							<TitleValue
+								key={omraade}
+								kodeverk={FullmaktKodeverk.Tema}
+								value={omraade}
+								size={'full-width'}
+							/>
+						)
+					)}
 					<TitleValue title="Kilde" value={data.kilde} />
 					<TitleValue title="Gyldig fra og med" value={Formatters.formatDate(data.gyldigFom)} />
 					<TitleValue title="Gyldig til og med" value={Formatters.formatDate(data.gyldigTom)} />

--- a/src/main/web_src/src/components/fagsystem/tpsf/visning/partials/Fullmakt.tsx
+++ b/src/main/web_src/src/components/fagsystem/tpsf/visning/partials/Fullmakt.tsx
@@ -2,8 +2,9 @@ import React from 'react'
 import SubOverskrift from '~/components/ui/subOverskrift/SubOverskrift'
 import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import Formatters from '~/utils/DataFormatter'
-import { Historikk } from '~/components/ui/historikk/Historikk'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
+import { DollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
+import { FullmaktKodeverk } from '~/config/kodeverk'
 
 type Data = {
 	data: FullmaktData
@@ -19,6 +20,7 @@ type FullmaktData = {
 	kilde: string
 	omraader: []
 	fullmektig: Fullmektig
+	id: number
 }
 
 type Fullmektig = {
@@ -31,13 +33,21 @@ type Fullmektig = {
 }
 
 export const Visning = ({ data }: Data) => {
-	const fullmektig = data.fullmektig
+	const { etternavn, fornavn, ident, identtype, kjonn, mellomnavn } = data.fullmektig
 
 	return (
 		<>
 			<div className="person-visning_content">
 				<ErrorBoundary>
-					<TitleValue title="Områder" value={Formatters.omraaderArrayToString(data.omraader)} />
+					<DollyFieldArray header={'Områder'} data={data.omraader} nested>
+						{(omraade: string) =>
+							omraade.includes('*') ? (
+								<TitleValue title="Tema" value={'Alle (*)'} />
+							) : (
+								<TitleValue title="Tema" kodeverk={FullmaktKodeverk.Tema} value={omraade} />
+							)
+						}
+					</DollyFieldArray>
 					<TitleValue title="Kilde" value={data.kilde} />
 					<TitleValue title="Gyldig fra og med" value={Formatters.formatDate(data.gyldigFom)} />
 					<TitleValue title="Gyldig til og med" value={Formatters.formatDate(data.gyldigTom)} />
@@ -45,11 +55,11 @@ export const Visning = ({ data }: Data) => {
 			</div>
 			<h4 style={{ marginTop: '0px' }}>Fullmektig</h4>
 			<div className="person-visning_content">
-				<TitleValue title={fullmektig.identtype} value={fullmektig.ident} />
-				<TitleValue title="Fornavn" value={fullmektig.fornavn} />
-				<TitleValue title="Mellomnavn" value={fullmektig.mellomnavn} />
-				<TitleValue title="Etternavn" value={fullmektig.etternavn} />
-				<TitleValue title="Kjønn" value={Formatters.kjonnToString(fullmektig.kjonn)} />
+				<TitleValue title={identtype} value={ident} />
+				<TitleValue title="Fornavn" value={fornavn} />
+				<TitleValue title="Mellomnavn" value={mellomnavn} />
+				<TitleValue title="Etternavn" value={etternavn} />
+				<TitleValue title="Kjønn" value={Formatters.kjonnToString(kjonn)} />
 			</div>
 		</>
 	)
@@ -60,8 +70,10 @@ export const Fullmakt = ({ data }: DataListe) => {
 	return (
 		<div>
 			<SubOverskrift label="Fullmakt" iconKind="fullmakt" />
-			{/* @ts-ignore */}
-			<Historikk component={Visning} data={data} />
+
+			<DollyFieldArray data={data} nested>
+				{(fullmakt: FullmaktData) => <Visning key={fullmakt.id} data={fullmakt} />}
+			</DollyFieldArray>
 		</div>
 	)
 }

--- a/src/main/web_src/src/components/fagsystem/tpsf/visning/partials/Vergemaal.tsx
+++ b/src/main/web_src/src/components/fagsystem/tpsf/visning/partials/Vergemaal.tsx
@@ -3,8 +3,8 @@ import { VergemaalKodeverk } from '~/config/kodeverk'
 import SubOverskrift from '~/components/ui/subOverskrift/SubOverskrift'
 import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import Formatters from '~/utils/DataFormatter'
-import { Historikk } from '~/components/ui/historikk/Historikk'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
+import { DollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
 
 type Data = {
 	data: VergemaalData
@@ -20,6 +20,7 @@ type VergemaalData = {
 	sakType: string
 	vedtakDato: string
 	verge: Verge
+	id: number
 }
 
 type Verge = {
@@ -32,7 +33,7 @@ type Verge = {
 }
 
 export const Visning = ({ data }: Data) => {
-	const verge = data.verge
+	const { etternavn, fornavn, ident, identtype, kjonn, mellomnavn } = data.verge
 	return (
 		<>
 			<div className="person-visning_content">
@@ -53,11 +54,11 @@ export const Visning = ({ data }: Data) => {
 			</div>
 			<h4 style={{ marginTop: '0px' }}>Verge</h4>
 			<div className="person-visning_content">
-				<TitleValue title={verge.identtype} value={verge.ident} />
-				<TitleValue title="Fornavn" value={verge.fornavn} />
-				<TitleValue title="Mellomnavn" value={verge.mellomnavn} />
-				<TitleValue title="Etternavn" value={verge.etternavn} />
-				<TitleValue title="Kjønn" value={Formatters.kjonnToString(verge.kjonn)} />
+				<TitleValue title={identtype} value={ident} />
+				<TitleValue title="Fornavn" value={fornavn} />
+				<TitleValue title="Mellomnavn" value={mellomnavn} />
+				<TitleValue title="Etternavn" value={etternavn} />
+				<TitleValue title="Kjønn" value={Formatters.kjonnToString(kjonn)} />
 			</div>
 		</>
 	)
@@ -68,8 +69,10 @@ export const Vergemaal = ({ data }: DataListe) => {
 	return (
 		<div>
 			<SubOverskrift label="Vergemål" iconKind="vergemaal" />
-			{/* @ts-ignore */}
-			<Historikk component={Visning} data={data} />
+
+			<DollyFieldArray data={data} nested>
+				{(vergemaal: VergemaalData) => <Visning key={vergemaal.id} data={vergemaal} />}
+			</DollyFieldArray>
 		</div>
 	)
 }

--- a/src/main/web_src/src/components/ui/titleValue/TitleValue.js
+++ b/src/main/web_src/src/components/ui/titleValue/TitleValue.js
@@ -26,7 +26,7 @@ export const TitleValue = ({ kodeverk = null, ...restProps }) => {
 			<P_TitleValue {...rest}>
 				<KodeverkConnector navn={kodeverk} value={value}>
 					{(kodeverkValues, kodeverkValue) => {
-						if (!kodeverkValue) return <Loading />
+						if (!kodeverkValue) return !kodeverkValues ? <Loading /> : value
 						return _isFunction(restProps.children)
 							? restProps.children(kodeverkValue)
 							: kodeverkValue.label

--- a/src/main/web_src/src/components/ui/titleValue/TitleValue.less
+++ b/src/main/web_src/src/components/ui/titleValue/TitleValue.less
@@ -22,6 +22,9 @@
 	&_xlarge {
 		flex: 0 1 480px;
 	}
+	&_full-width {
+		flex: 0 1 100%;
+	}
 
 	h1,
 	h2,

--- a/src/main/web_src/src/config/kodeverk/index.ts
+++ b/src/main/web_src/src/config/kodeverk/index.ts
@@ -15,7 +15,7 @@ export enum VergemaalKodeverk {
 }
 
 export enum FullmaktKodeverk {
-	tema = 'Tema'
+	Tema = 'Tema'
 }
 
 export enum AdresseKodeverk {

--- a/src/main/web_src/src/service/SelectOptionsOppslag.js
+++ b/src/main/web_src/src/service/SelectOptionsOppslag.js
@@ -135,12 +135,17 @@ SelectOptionsOppslag.formatOptions = (type, data) => {
 		return options
 	} else if (type === 'fullmaktOmraader') {
 		const omraader = data.value ? Object.entries(data.value.data.koder) : []
+		const ugyldigeKoder = ['BII', 'KLA', 'KNA', 'KOM', 'LGA', 'MOT', 'OVR']
 		const options = []
 		options.push({ value: '*', label: '* (Alle)' })
-		omraader.forEach(omraade => {
-			data = omraade[1]
-			options.push({ value: data.value, label: data.label })
-		})
+		omraader
+			.filter(omr => {
+				return !ugyldigeKoder.includes(omr[1].value)
+			})
+			.forEach(omraade => {
+				data = omraade[1]
+				options.push({ value: data.value, label: data.label })
+			})
 		return options
 	}
 }

--- a/src/main/web_src/src/service/services/dolly/Utils.js
+++ b/src/main/web_src/src/service/services/dolly/Utils.js
@@ -116,11 +116,6 @@ export const SortKodeverkArray = data => {
 		}))
 	}
 
-	if (data.name === 'Tema') {
-		const ugyldigeKoder = ['BII', 'KLA', 'KNA', 'KOM', 'LGA', 'MOT', 'OVR']
-		return kodeverk.filter(kode => !ugyldigeKoder.includes(kode.value))
-	}
-
 	if (data.name === 'Vergemål_Mandattype') {
 		return kodeverk.filter(kode => kode.value !== '<Blank>' && kode.value !== 'ADP')
 	}

--- a/src/main/web_src/src/service/services/dolly/Utils.js
+++ b/src/main/web_src/src/service/services/dolly/Utils.js
@@ -116,6 +116,11 @@ export const SortKodeverkArray = data => {
 		}))
 	}
 
+	if (data.name === 'Tema') {
+		const ugyldigeKoder = ['BII', 'KLA', 'KNA', 'KOM', 'LGA', 'MOT', 'OVR']
+		return kodeverk.filter(kode => !ugyldigeKoder.includes(kode.value))
+	}
+
 	if (data.name === 'Vergemål_Mandattype') {
 		return kodeverk.filter(kode => kode.value !== '<Blank>' && kode.value !== 'ADP')
 	}

--- a/src/main/web_src/src/styles/utils.less
+++ b/src/main/web_src/src/styles/utils.less
@@ -74,7 +74,7 @@
 	}
 
 	&--full-width {
-		width: 100pc;
+		width: 100%;
 	}
 }
 


### PR DESCRIPTION
Ble et par design endringer rundt dette og refaktorering.
Endret kodeverk hentings funksjonalitet til å returnere innsendt value dersom den ikke klarer å mappe kodeverk verdi
Bruker også filtrert tema liste i fullmakt nå, på samme måte som for dokarkiv 👍 

Er litt usikker på om områder listen tar litt mye plass dersom man velger mange områder, kan eventuelt bare bruke forkortelsene som Titlevalue dersom man har mer enn 4 f.eks? 🤓 