### PR TITLE
Lagt til automatisk avhuking av q1 og q2 ved innsending av sykemelding

### DIFF
--- a/src/main/web_src/src/components/miljoVelger/MiljoVelger.js
+++ b/src/main/web_src/src/components/miljoVelger/MiljoVelger.js
@@ -54,6 +54,11 @@ export const MiljoVelger = ({ bestillingsdata, heading }) => {
 						)
 					}
 
+					if (bestillingsdata.sykemelding && !isChecked('q1') && !isChecked('q2')) {
+						push('q1')
+						push('q2')
+					}
+
 					return order.map(type => {
 						const category = filteredEnvironments[type]
 						if (!category) return null


### PR DESCRIPTION
Siden å glemme denne avhukingen er en vanlig kilde til feil. Man kan fortsatt huke de av igjen, men de følger med avhuket som standard mot slutten av bestilling.