### PR TITLE
Oppdatert loading labels

### DIFF
--- a/src/main/web_src/src/app/App.js
+++ b/src/main/web_src/src/app/App.js
@@ -49,7 +49,7 @@ export default class App extends Component {
 
 		if (this.state.criticalError) return <CriticalError error={this.state.criticalError.stack} />
 
-		if (!brukerData || !configReady) return <Loading label="laster dolly applikasjon" fullpage />
+		if (!brukerData || !configReady) return <Loading label="Laster dolly applikasjon" fullpage />
 		return (
 			<React.Fragment>
 				<Utlogging />

--- a/src/main/web_src/src/components/fagsystem/brregstub/visning/BrregVisning.js
+++ b/src/main/web_src/src/components/fagsystem/brregstub/visning/BrregVisning.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import _get from 'lodash/get'
 import SubOverskrift from '~/components/ui/subOverskrift/SubOverskrift'
 import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import { DollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
@@ -8,7 +7,7 @@ import Loading from '~/components/ui/loading/Loading'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
 
 export const BrregVisning = ({ data, loading }) => {
-	if (loading) return <Loading label="laster brreg-data" />
+	if (loading) return <Loading label="Laster brreg-data" />
 	if (!data) return false
 
 	return (

--- a/src/main/web_src/src/components/fagsystem/dokarkiv/visning/Visning.tsx
+++ b/src/main/web_src/src/components/fagsystem/dokarkiv/visning/Visning.tsx
@@ -55,6 +55,7 @@ export default ({ ident }: Form) => (
 					)
 				)
 			}}
+			label="Laster dokarkiv data"
 		/>
 	</div>
 )

--- a/src/main/web_src/src/components/fagsystem/inntektsmelding/visning/Visning.tsx
+++ b/src/main/web_src/src/components/fagsystem/inntektsmelding/visning/Visning.tsx
@@ -17,12 +17,12 @@ import JoarkDokumentService, {
 } from '~/service/services/JoarkDokumentService'
 import LoadableComponentWithRetry from '~/components/ui/loading/LoadableComponentWithRetry'
 
-interface InntektsmeldingVisning {
+interface InntektsmeldingVisningProps {
 	liste: Array<BestillingData>
 	ident: string
 }
 
-export const InntektsmeldingVisning = ({ liste, ident }: InntektsmeldingVisning) => {
+export const InntektsmeldingVisning = ({ liste, ident }: InntektsmeldingVisningProps) => {
 	//Viser data fra bestillingen
 	if (!liste || liste.length < 1) return null
 
@@ -93,6 +93,7 @@ export const InntektsmeldingVisning = ({ liste, ident }: InntektsmeldingVisning)
 					}
 				}
 			}}
+			label="Laster inntektsmelding data"
 		/>
 	)
 }

--- a/src/main/web_src/src/components/fagsystem/inntektsmelding/visning/partials/pleiepengerVisning.tsx
+++ b/src/main/web_src/src/components/fagsystem/inntektsmelding/visning/partials/pleiepengerVisning.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import _isEmpty from 'lodash/isEmpty'
 import { DollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
 import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import Formatters from '~/utils/DataFormatter'

--- a/src/main/web_src/src/components/fagsystem/inst/visning/InstVisning.js
+++ b/src/main/web_src/src/components/fagsystem/inst/visning/InstVisning.js
@@ -18,7 +18,7 @@ const getSortedData = data => {
 }
 
 export const InstVisning = ({ data, loading }) => {
-	if (loading) return <Loading label="laster inst data" />
+	if (loading) return <Loading label="Laster inst data" />
 	if (!data) return false
 
 	const sortedData = getSortedData(data)

--- a/src/main/web_src/src/components/fagsystem/krrstub/visning/KrrVisning.tsx
+++ b/src/main/web_src/src/components/fagsystem/krrstub/visning/KrrVisning.tsx
@@ -8,12 +8,12 @@ import { KrrApi } from '~/service/Api'
 import LoadableComponent from '~/components/ui/loading/LoadableComponent'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
 
-type KrrVisning = {
+type KrrVisningProps = {
 	data: Array<Data>
 	loading: boolean
 }
 
-type Visning = {
+type VisningProps = {
 	data: Data
 }
 
@@ -34,7 +34,7 @@ type SdpLeverandoer = {
 	}
 }
 
-export const Visning = ({ data }: Visning) => {
+export const Visning = ({ data }: VisningProps) => {
 	return (
 		<>
 			<LoadableComponent
@@ -74,13 +74,14 @@ export const Visning = ({ data }: Visning) => {
 						</>
 					)
 				}
+				label="Laster KRR data"
 			/>
 		</>
 	)
 }
 
-export const KrrVisning = ({ data, loading }: KrrVisning) => {
-	if (loading) return <Loading label="Laster krr data" />
+export const KrrVisning = ({ data, loading }: KrrVisningProps) => {
+	if (loading) return <Loading label="Laster KRR data" />
 	if (!data) return false
 
 	const sortedData = Array.isArray(data) ? data.slice().reverse() : data

--- a/src/main/web_src/src/components/fagsystem/krrstub/visning/KrrVisning.tsx
+++ b/src/main/web_src/src/components/fagsystem/krrstub/visning/KrrVisning.tsx
@@ -80,7 +80,7 @@ export const Visning = ({ data }: Visning) => {
 }
 
 export const KrrVisning = ({ data, loading }: KrrVisning) => {
-	if (loading) return <Loading label="laster krr data" />
+	if (loading) return <Loading label="Laster krr data" />
 	if (!data) return false
 
 	const sortedData = Array.isArray(data) ? data.slice().reverse() : data

--- a/src/main/web_src/src/components/fagsystem/pdlf/visning/Visning.js
+++ b/src/main/web_src/src/components/fagsystem/pdlf/visning/Visning.js
@@ -3,19 +3,18 @@ import { UtenlandsId } from './partials/UtenlandsId'
 import { FalskIdentitet } from './partials/FalskIdentitet'
 import { KontaktinformasjonForDoedsbo } from './partials/KontaktinformasjonForDoedsbo'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
+import Loading from '~/components/ui/loading/Loading'
 
 export const PdlfVisning = ({ data, loading }) => {
+	if (loading) return <Loading label="Laster PDL-data" />
 	if (!data || !data.data || !data.data.hentPerson) return false
 	const { hentPerson } = data.data
 	return (
 		<ErrorBoundary>
 			<div>
-				<UtenlandsId data={hentPerson.utenlandskIdentifikasjonsnummer} loading={loading} />
-				<FalskIdentitet data={hentPerson.falskIdentitet} loading={loading} />
-				<KontaktinformasjonForDoedsbo
-					data={hentPerson.kontaktinformasjonForDoedsbo}
-					loading={loading}
-				/>
+				<UtenlandsId data={hentPerson.utenlandskIdentifikasjonsnummer} />
+				<FalskIdentitet data={hentPerson.falskIdentitet} />
+				<KontaktinformasjonForDoedsbo data={hentPerson.kontaktinformasjonForDoedsbo} />
 			</div>
 		</ErrorBoundary>
 	)

--- a/src/main/web_src/src/components/fagsystem/pdlf/visning/partials/FalskIdentitet.js
+++ b/src/main/web_src/src/components/fagsystem/pdlf/visning/partials/FalskIdentitet.js
@@ -2,11 +2,9 @@ import React, { Fragment } from 'react'
 import SubOverskrift from '~/components/ui/subOverskrift/SubOverskrift'
 import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import { Personnavn } from './Personnavn'
-import Loading from '~/components/ui/loading/Loading'
 import Formatters from '~/utils/DataFormatter'
 
-export const FalskIdentitet = ({ data, loading }) => {
-	if (loading) return <Loading label="laster PDL-data" />
+export const FalskIdentitet = ({ data }) => {
 	if (!data) return false
 	const {
 		rettIdentitetVedOpplysninger,

--- a/src/main/web_src/src/components/fagsystem/pdlf/visning/partials/KontaktinformasjonForDoedsbo.js
+++ b/src/main/web_src/src/components/fagsystem/pdlf/visning/partials/KontaktinformasjonForDoedsbo.js
@@ -3,13 +3,11 @@ import { AdresseKodeverk } from '~/config/kodeverk'
 import SubOverskrift from '~/components/ui/subOverskrift/SubOverskrift'
 import { DollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
 import { TitleValue } from '~/components/ui/titleValue/TitleValue'
-import Loading from '~/components/ui/loading/Loading'
 import Formatters from '~/utils/DataFormatter'
 import { Personnavn } from './Personnavn'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
 
-export const KontaktinformasjonForDoedsbo = ({ data, loading }) => {
-	if (loading) return <Loading label="laster PDL-data" />
+export const KontaktinformasjonForDoedsbo = ({ data }) => {
 	if (!data || data.length === 0) return false
 
 	return (

--- a/src/main/web_src/src/components/fagsystem/pdlf/visning/partials/UtenlandsId.js
+++ b/src/main/web_src/src/components/fagsystem/pdlf/visning/partials/UtenlandsId.js
@@ -4,11 +4,9 @@ import SubOverskrift from '~/components/ui/subOverskrift/SubOverskrift'
 import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import { DollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
 import Formatters from '~/utils/DataFormatter'
-import Loading from '~/components/ui/loading/Loading'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
 
-export const UtenlandsId = ({ data, loading }) => {
-	if (loading) return <Loading label="laster PDL-data" />
+export const UtenlandsId = ({ data }) => {
 	if (!data || data.length === 0) return false
 
 	return (

--- a/src/main/web_src/src/components/fagsystem/pensjon/visning/PensjonVisning.js
+++ b/src/main/web_src/src/components/fagsystem/pensjon/visning/PensjonVisning.js
@@ -6,7 +6,7 @@ import { DollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
 
 export const PensjonVisning = ({ data, loading }) => {
-	if (loading) return <Loading label="laster pensjonforvalter-data" />
+	if (loading) return <Loading label="Laster pensjonforvalter-data" />
 	if (!data || data.length === 0) return false
 
 	return (

--- a/src/main/web_src/src/components/fagsystem/sigrunstub/visning/Visning.js
+++ b/src/main/web_src/src/components/fagsystem/sigrunstub/visning/Visning.js
@@ -1,14 +1,12 @@
 import React from 'react'
-import _get from 'lodash/get'
 import SubOverskrift from '~/components/ui/subOverskrift/SubOverskrift'
 import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import { DollyFieldArray } from '~/components/ui/form/fieldArray/DollyFieldArray'
-import Formatters from '~/utils/DataFormatter'
 import Loading from '~/components/ui/loading/Loading'
 import { ErrorBoundary } from '~/components/ui/appError/ErrorBoundary'
 
 export const SigrunstubVisning = ({ data, loading, visTittel = true }) => {
-	if (loading) return <Loading label="laster sigrunstub-data" />
+	if (loading) return <Loading label="Laster sigrunstub-data" />
 	if (!data || data.length === 0) return false
 	const grunnlag = data[0].grunnlag.length > 0
 	const svalbardGrunnlag = data[0].svalbardGrunnlag.length > 0

--- a/src/main/web_src/src/components/fagsystem/sykdom/visning/partials/DetaljertSykemelding.tsx
+++ b/src/main/web_src/src/components/fagsystem/sykdom/visning/partials/DetaljertSykemelding.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react'
-import _get from 'lodash/get'
-import _has from 'lodash/has'
 import Formatters from '~/utils/DataFormatter'
 import { TitleValue } from '~/components/ui/titleValue/TitleValue'
 import { Bidiagnoser } from './Bidiagnoser'

--- a/src/main/web_src/src/components/miljoVelger/MiljoeInfo/TilgjengeligeMiljoer.js
+++ b/src/main/web_src/src/components/miljoVelger/MiljoeInfo/TilgjengeligeMiljoer.js
@@ -10,7 +10,7 @@ export default function TilgjengeligeMiljoer({ endepunkt, dollyEnvironments }) {
 		return response
 	}, [endepunkt])
 
-	let message = 'laster tilgjengelige miljøer..'
+	let message = 'Laster tilgjengelige miljøer..'
 
 	if (state.value && state.value.data) {
 		message = Formatters.arrayToString(filterMiljoe(dollyEnvironments, state.value.data))

--- a/src/main/web_src/src/components/organisasjonSelect/OrganisasjonLoader.tsx
+++ b/src/main/web_src/src/components/organisasjonSelect/OrganisasjonLoader.tsx
@@ -40,6 +40,10 @@ export const OrganisasjonLoader = ({
 					}))
 		)
 	return (
-		<LoadableComponentWithRetry onFetch={onFetch} render={(list: Organisasjon[]) => render(list)} />
+		<LoadableComponentWithRetry
+			onFetch={onFetch}
+			render={(list: Organisasjon[]) => render(list)}
+			label="Laster organisasjoner"
+		/>
 	)
 }

--- a/src/main/web_src/src/components/ui/loading/LoadableComponent.tsx
+++ b/src/main/web_src/src/components/ui/loading/LoadableComponent.tsx
@@ -1,16 +1,17 @@
 import React, { useEffect, useState } from 'react'
 import Loading from './Loading'
 
-interface LoadableComponent {
+interface LoadableComponentProps {
 	onFetch: any
 	render: (data: any, feilmelding: Feilmelding) => JSX.Element
+	label?: string
 }
 
 export type Feilmelding = {
 	feilmelding?: string
 }
 
-const LoadableComponent = ({ onFetch, render }: LoadableComponent) => {
+const LoadableComponent = ({ onFetch, render, label }: LoadableComponentProps) => {
 	const [loading, setLoading] = useState(true)
 	const [error, setError] = useState()
 	const [data, setData] = useState()
@@ -27,7 +28,7 @@ const LoadableComponent = ({ onFetch, render }: LoadableComponent) => {
 	}, [])
 
 	if (loading) {
-		return <Loading />
+		return <Loading label={label} />
 	}
 	const feilmelding: Feilmelding = error
 		? {

--- a/src/main/web_src/src/components/ui/loading/LoadableComponentWithRetry.tsx
+++ b/src/main/web_src/src/components/ui/loading/LoadableComponentWithRetry.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 interface LoadableComponent<T> {
 	onFetch: () => Promise<T>
 	render: (data: T) => JSX.Element
+	label?: string
 }
 
 const Knapp = styled(NavKnapp)`
@@ -19,7 +20,7 @@ const Alert = styled(AlertStripeFeil)`
 	margin-right: 15px;
 `
 
-function LoadableComponentWithRetry<T>({ onFetch, render }: LoadableComponent<T>) {
+function LoadableComponentWithRetry<T>({ onFetch, render, label }: LoadableComponent<T>) {
 	const [loading, setLoading] = useState(true)
 	const [error, setError] = useState<boolean>(false)
 	const [data, setData] = useState<T>()
@@ -45,7 +46,7 @@ function LoadableComponentWithRetry<T>({ onFetch, render }: LoadableComponent<T>
 	}, [])
 
 	if (loading) {
-		return <Loading />
+		return <Loading label={label} />
 	}
 	if (error) {
 		return (

--- a/src/main/web_src/src/pages/gruppe/PersonListe/PersonListe.js
+++ b/src/main/web_src/src/pages/gruppe/PersonListe/PersonListe.js
@@ -63,7 +63,7 @@ export default function PersonListe({
 		}
 	}, [identer])
 
-	if (isFetching) return <Loading label="laster personer" panel />
+	if (isFetching) return <Loading label="Laster personer" panel />
 
 	if (visPerson && personListe && window.sessionStorage.getItem('sidetall')) {
 		setSidetall(parseInt(window.sessionStorage.getItem('sidetall')))

--- a/src/main/web_src/src/pages/gruppeOversikt/Liste.js
+++ b/src/main/web_src/src/pages/gruppeOversikt/Liste.js
@@ -18,7 +18,7 @@ export default function Liste({
 	setSidetall,
 	setSideStoerrelse
 }) {
-	if (isFetching) return <Loading label="laster grupper" panel />
+	if (isFetching) return <Loading label="Laster grupper" panel />
 
 	if (!items || !items.length) {
 		return (

--- a/src/main/web_src/src/pages/soekMiniNorge/search/ImportTilDolly/gruppe/EksisterendeGruppe.tsx
+++ b/src/main/web_src/src/pages/soekMiniNorge/search/ImportTilDolly/gruppe/EksisterendeGruppe.tsx
@@ -37,7 +37,7 @@ export default ({
 		label: v.id + ' - ' + v.navn
 	}))
 
-	if (isFetching) return <Loading label="laster grupper" />
+	if (isFetching) return <Loading label="Laster grupper" />
 
 	return (
 		<DollySelect


### PR DESCRIPTION
Fjernet duplikate "Laster PDL data" meldinger i personvisning. La merke til at det var en annen melding det bare sto "Laster" på. Så jeg har lagt til `label`-prop for `LoadableComponent` og `LoadableComponentWithRetry` sånn at man kan sette en mer spesifikk  "Laster"-melding. 

Ble også litt kode rydding :)